### PR TITLE
Fixed type and reference of handle for pthread_create() in src/karel/…

### DIFF
--- a/karel/draw.c
+++ b/karel/draw.c
@@ -151,12 +151,11 @@ void drawBeeperCounter() {
     {
         temp[0] = 'o';
         temp[1] = 'o';
+        temp[2] = '\0';
     }
 
-    char dest[20];
-
-    strcpy( dest, beeperCounter );
-    strcat( dest, temp );
+    char dest[30];
+	snprintf(dest, sizeof(dest), "Beeper(s) in Bag: %s", temp);
 
 	drawString(dest, world.speedMinusButtonX, 6 * TILE_SIZE, font, 0, 0, 0);
 }

--- a/src/karel/draw.c
+++ b/src/karel/draw.c
@@ -151,6 +151,7 @@ void drawBeeperCounter() {
     {
         temp[0] = 'o';
         temp[1] = 'o';
+        temp[2] = '\0';
     }
 
     char dest[20];

--- a/src/karel/draw.c
+++ b/src/karel/draw.c
@@ -142,7 +142,6 @@ void drawMenu() {
 
 
 void drawBeeperCounter() {
-	char* beeperCounter = "Beeper(s) in Bag: ";
 	char temp[10];
 
 	if (world.beeperBag < INFINITE_BEEPERS)
@@ -154,10 +153,8 @@ void drawBeeperCounter() {
         temp[2] = '\0';
     }
 
-    char dest[20];
-
-    strcpy( dest, beeperCounter );
-    strcat( dest, temp );
+    char dest[30];
+	snprintf(dest, sizeof(dest), "Beeper(s) in Bag: %s", temp);
 
 	drawString(dest, world.speedMinusButtonX, 6 * TILE_SIZE, font, 0, 0, 0);
 }

--- a/src/karel/input.c
+++ b/src/karel/input.c
@@ -6,7 +6,7 @@
 //to replace windows.h stuff
 typedef unsigned long DWORD;
 #define WINAPI
-typedef void * HANDLE;
+typedef pthread_t HANDLE;
 #endif
 
 
@@ -74,11 +74,11 @@ void getInput() {
                     			if (isStarted == 0)
                     			{
                         			//run();
-									#if BUILD == WINDOWS_BUILD
-                        			runThread = CreateThread(Null, 0, runPointer, Null, 0, Null);
-									#elif BUILD == UNIX_BUILD
-									pthread_create(runThread, Null, runPointer, Null);
-									#endif
+						#if BUILD == WINDOWS_BUILD
+							runThread = CreateThread(Null, 0, runPointer, Null, 0, Null);
+						#elif BUILD == UNIX_BUILD
+							pthread_create(&runThread, Null, runPointer, Null);
+						#endif
                     			}
 
 					//isStarted = 1;


### PR DESCRIPTION
Fixed type and reference of handle for pthread_create() in src/karel/input.c (segfaulted otherwise, because of dangling void-pointer passed to pthread_create())

Null-terminated infinity-sign in src/karel/draw.c (showed "oogo" previously)